### PR TITLE
[ONNX][Loop] Fix passing parameters from parent graph scope to subgraph

### DIFF
--- a/ngraph/core/include/ngraph/node.hpp
+++ b/ngraph/core/include/ngraph/node.hpp
@@ -100,6 +100,7 @@ namespace ngraph
     NGRAPH_API
     NodeVector as_node_vector(const OutputVector& values);
     /// Returns a ResultVector referencing values.
+    NGRAPH_API
     ResultVector as_result_vector(const OutputVector& values);
 
     /// Alias useful for cloning

--- a/ngraph/frontend/onnx_import/include/onnx_import/core/graph.hpp
+++ b/ngraph/frontend/onnx_import/include/onnx_import/core/graph.hpp
@@ -64,13 +64,15 @@ namespace ngraph
             void add_provenance_tags(const Node& onnx_node,
                                      const OutputVector& ng_node_vector) const;
 
+        protected:
+            ParameterVector m_parameters;
+
         private:
             const ONNX_NAMESPACE::GraphProto* m_graph_proto;
             std::unique_ptr<GraphCache> m_cache;
             std::vector<Node> m_nodes;
             std::vector<ValueInfo> m_inputs;
             std::vector<ValueInfo> m_outputs;
-            ParameterVector m_parameters;
             Model* m_model;
         };
 

--- a/ngraph/frontend/onnx_import/src/op/loop.cpp
+++ b/ngraph/frontend/onnx_import/src/op/loop.cpp
@@ -116,15 +116,15 @@ namespace ngraph
                     const auto& graph_outputs = body_graph.get_ng_outputs();
                     const auto& graph_inputs = body_graph.get_ng_parameters();
 
-                    CHECK_VALID_NODE(
-                        node,
-                        graph_inputs.size() == loop_carried_dependencies.size() + 2,
-                        "The provided loop body graph inputs size (",
-                        graph_inputs.size(),
-                        "), is not equal to the sum of loop carried dependencies and two mandatory"
-                        " inputs (",
-                        loop_carried_dependencies.size() + 2,
-                        ")");
+                    CHECK_VALID_NODE(node,
+                                     graph_inputs.size() >= loop_carried_dependencies.size() + 2,
+                                     "The provided loop body graph inputs size (",
+                                     graph_inputs.size(),
+                                     "), is not greater than the sum of loop carried dependencies "
+                                     "and two mandatory"
+                                     " inputs (",
+                                     loop_carried_dependencies.size() + 2,
+                                     ")");
 
                     CHECK_VALID_NODE(node,
                                      graph_outputs.size() >= loop_carried_dependencies.size() + 1,


### PR DESCRIPTION
After removing `Lambda` in https://github.com/openvinotoolkit/openvino/pull/1830 it turned out that passing parameters (not initializes) from parent graph to subgraph does not work correctly (as a results a few unit tests fail).